### PR TITLE
Add rust dependecies and pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk add --no-cache ca-certificates python3 gcc python3-dev libc-dev libffi libffi-dev openssl openssl-dev && mkdir -p /repo/netherappbot
+RUN apk add --no-cache ca-certificates rust cargo python3 gcc python3-dev libc-dev libffi libffi-dev openssl openssl-dev py3-pip && mkdir -p /repo/netherappbot
 ADD setup.py README.rst LICENSE setup.cfg /repo/
 ADD netherappbot/*.py /repo/netherappbot/
 RUN pip3 install /repo/ && rm -rf /repo && apk del gcc python3-dev libc-dev libffi-dev openssl-dev


### PR DESCRIPTION
Hi! 
I've tried building this image on my ubuntu server saw some errors. First one is missing `pip3`. I've added a `py3-pip` package to fix it. 
After that a `cryptography` transitive dependency missed a rust compiler (wtf?). I've also added it. 